### PR TITLE
TMDB-DAO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/*
 src/main/resources/apikey
+src/main/resources/TMDB_apikey

--- a/src/main/java/data_access/MovieDBDataAccessException.java
+++ b/src/main/java/data_access/MovieDBDataAccessException.java
@@ -1,0 +1,10 @@
+package data_access;
+
+/**
+ * Exception thrown when there is an error with accessing data from the TMDB API.
+ */
+public class MovieDBDataAccessException extends Exception {
+    public MovieDBDataAccessException(String string) {
+        super(string);
+    }
+}

--- a/src/main/java/data_access/MovieDBDataAccessObject.java
+++ b/src/main/java/data_access/MovieDBDataAccessObject.java
@@ -2,13 +2,6 @@ package data_access;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-
-import use_case.generate_recommendations.MovieDBDataAccessInterface;
-
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -16,6 +9,10 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import use_case.generate_recommendations.MovieDBDataAccessInterface;
 
 /**
  * The DAO for the TMDB, responsible for getting information about movies and shows.

--- a/src/main/java/data_access/MovieDBDataAccessObject.java
+++ b/src/main/java/data_access/MovieDBDataAccessObject.java
@@ -1,0 +1,185 @@
+package data_access;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import use_case.generate_recommendations.MovieDBDataAccessInterface;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+
+/**
+ * The DAO for the TMDB, responsible for getting information about movies and shows.
+ * See
+ *  * <a href= "https://developer.themoviedb.org/docs/getting-started">
+ *  the documentation</a>
+ * for more details.
+ */
+public class MovieDBDataAccessObject implements MovieDBDataAccessInterface {
+
+    private static final String MESSAGE = "message";
+    private static final String GENRES = "genres";
+    private static final String RUNTIME = "runtime";
+    private static final int CAST_LIMIT = 5;
+    private static final String ACCEPT = "accept";
+    private static final String CONTENT_TYPE = "application/json";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
+    private String apiKey;
+
+    /**
+     * Get the complete details of a movie from the TMDB.
+     * @param movieName The name of the movie to be looked up.
+     * @return a JSONObject containing the movie genres, cast, runtime, rating, and description.
+     * @throws MovieDBDataAccessException if the TMDB API is unsuccessfully called.
+     */
+    public JSONObject getCompleteMovieData(String movieName) throws MovieDBDataAccessException {
+        final int movieID = getMovieID(movieName);
+        final JSONObject completeMovieData = getMovieDetails(movieID);
+        completeMovieData.put("cast", getMovieCast(movieID));
+        return completeMovieData;
+    }
+
+    /**
+     * Get the ID of a movie from the TMDB.
+     * @param movieName The name of the movie to be looked up.
+     * @return the TMDB ID of the corresponding movie.
+     * @throws MovieDBDataAccessException if the TMDB API is unsuccessfully called.
+     * @throws RuntimeException if there's an error formatting the JSON output.
+     */
+    private int getMovieID(String movieName) throws MovieDBDataAccessException {
+
+        final OkHttpClient client = new OkHttpClient();
+
+        final Request request = new Request.Builder()
+                .url("https://api.themoviedb.org/3/search/movie?query=" + movieName
+                        + "&include_adult=true&language=en-US&page=1&api_key=" + apiKey)
+                .get()
+                .build();
+
+        try {
+            final Response response = client.newCall(request).execute();
+
+            final JSONObject responseBody = new JSONObject(response.body().string());
+
+            if (response.isSuccessful()) {
+                return responseBody.getJSONArray("results").getJSONObject(0).getInt("id");
+            }
+            else {
+                throw new MovieDBDataAccessException(responseBody.getString(MESSAGE));
+            }
+        }
+        catch (IOException | JSONException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Get the details of a movie from the TMDB.
+     * @param movieID The ID of the movie to be looked up.
+     * @return a JSONObject containing the movie's genres (in a JSONArray),
+     *      its runtime (in minutes), a description, a rating (out of 10.0).
+     * @throws MovieDBDataAccessException if the TMDB API is unsuccessfully called.
+     * @throws RuntimeException if there's an error formatting the JSON output.
+     */
+    private JSONObject getMovieDetails(int movieID) throws MovieDBDataAccessException {
+
+        final OkHttpClient client = new OkHttpClient();
+
+        final Request request = new Request.Builder()
+                .url("https://api.themoviedb.org/3/movie/" + movieID + "?language=en-US&api_key=" + apiKey)
+                .get()
+                .addHeader(ACCEPT, CONTENT_TYPE)
+                .addHeader(AUTHORIZATION, BEARER + apiKey)
+                .build();
+
+        try {
+            final Response response = client.newCall(request).execute();
+
+            final JSONObject responseBody = new JSONObject(response.body().string());
+
+            if (response.isSuccessful()) {
+                final JSONObject criticalMovieDetails = new JSONObject();
+                final JSONArray genres = responseBody.getJSONArray(GENRES);
+                final JSONArray parsedGenres = new JSONArray();
+                for (int i = 0; i < genres.length(); i++) {
+                    parsedGenres.put(genres.getJSONObject(i).getString("name"));
+                }
+                criticalMovieDetails.put(GENRES, parsedGenres);
+                criticalMovieDetails.put("rating", responseBody.getDouble("vote_average"));
+                criticalMovieDetails.put("description", responseBody.getString("overview"));
+                criticalMovieDetails.put(RUNTIME, responseBody.getInt(RUNTIME));
+                return criticalMovieDetails;
+            }
+            else {
+                throw new MovieDBDataAccessException(responseBody.getString(MESSAGE));
+            }
+        }
+        catch (IOException | JSONException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Get the cast of a movie from the TMDB.
+     * @param movieID The ID of the movie to be looked up.
+     * @return a JSONArray containing names of {@value #CAST_LIMIT} of the movie's cast members.
+     * @throws MovieDBDataAccessException if the TMDB API is unsuccessfully called.
+     * @throws RuntimeException if there's an error formatting the JSON output.
+     */
+    private JSONArray getMovieCast(int movieID) throws MovieDBDataAccessException {
+
+        final OkHttpClient client = new OkHttpClient();
+
+        final Request request = new Request.Builder()
+                .url("https://api.themoviedb.org/3/movie/" + movieID + "/credits?language=en-US&api_key=" + apiKey)
+                .get()
+                .addHeader(ACCEPT, CONTENT_TYPE)
+                .addHeader(AUTHORIZATION, BEARER + apiKey)
+                .build();
+
+        try {
+            final Response response = client.newCall(request).execute();
+
+            final JSONObject responseBody = new JSONObject(response.body().string());
+
+            if (response.isSuccessful()) {
+                final JSONArray cast = responseBody.getJSONArray("cast");
+                final JSONArray parsedCast = new JSONArray();
+                for (int i = 0; i < CAST_LIMIT; i++) {
+                    parsedCast.put(cast.getJSONObject(i).getString("name"));
+                }
+                return parsedCast;
+            }
+            else {
+                throw new MovieDBDataAccessException(responseBody.getString(MESSAGE));
+            }
+        }
+        catch (IOException | JSONException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Load the api key from the resources/apikey.
+     * @throws RuntimeException if there's an error reading the apikey file.
+     */
+    public void loadApiKeyFromFile() {
+        try {
+            this.apiKey = Files.readString(Paths.get(getClass().getClassLoader()
+                    .getResource("TMDB_apikey").toURI()));
+        }
+        catch (IOException | URISyntaxException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/use_case/generate_recommendations/MovieDBDataAccessInterface.java
+++ b/src/main/java/use_case/generate_recommendations/MovieDBDataAccessInterface.java
@@ -1,0 +1,25 @@
+package use_case.generate_recommendations;
+
+import org.json.JSONObject;
+
+import data_access.MovieDBDataAccessException;
+
+/**
+ * Interface for the TMDB. Includes methods for setting the API key and getting movie information.
+ */
+public interface MovieDBDataAccessInterface {
+
+    /**
+     * Get the complete details of a movie from the TMDB.
+     * @param movieName The name of the movie to be looked up.
+     * @return a JSONObject containing the movie genres, cast, runtime, rating, and description.
+     * @throws MovieDBDataAccessException if the TMDB API is unsuccessfully called.
+     */
+    JSONObject getCompleteMovieData(String movieName) throws MovieDBDataAccessException;
+
+    /**
+     * Loads the TMDB API key from the TMDB_apikey file in resources.
+     */
+    void loadApiKeyFromFile();
+
+}

--- a/src/test/java/data_access/MovieDBDataAccessObjectTest.java
+++ b/src/test/java/data_access/MovieDBDataAccessObjectTest.java
@@ -1,0 +1,53 @@
+package data_access;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import use_case.generate_recommendations.MovieDBDataAccessInterface;
+
+import static org.junit.Assert.*;
+
+public class MovieDBDataAccessObjectTest {
+
+    private static JSONObject movieDetails;
+    public static final String MOVIE_NAME = "The Matrix";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        MovieDBDataAccessInterface api = new MovieDBDataAccessObject();
+        api.loadApiKeyFromFile();
+        // Filename should be TMDB_apikey
+        movieDetails = api.getCompleteMovieData(MOVIE_NAME);
+    }
+
+    @Test
+    public void testHasRuntime() {
+        assertEquals(136, movieDetails.getInt("runtime"));
+    }
+
+    @Test
+    public void testHasRating() {
+        assertEquals(8.2, movieDetails.getDouble("rating"), 0.0);
+    }
+
+    @Test
+    public void testHasDescription() {
+        assertEquals("Set in the 22nd century, The Matrix tells " +
+                "the story of a computer hacker who joins a group of underground insurgents fighting the vast and " +
+                "powerful computers who now rule the earth.", movieDetails.getString("description"));
+    }
+
+    @Test
+    public void testHasCast() {
+            JSONArray cast = new JSONArray(new String[] {"Keanu Reeves","Laurence Fishburne","Carrie-Anne Moss",
+                    "Hugo Weaving", "Gloria Foster"});
+            assertTrue(cast.similar(movieDetails.getJSONArray("cast")));
+        }
+
+    @Test
+    public void testHasGenres() {
+        JSONArray genres = new JSONArray(new String[] {"Action", "Science Fiction"});
+        assertTrue(genres.similar(movieDetails.getJSONArray("genres")));
+    }
+}

--- a/src/test/java/data_access/MovieDBDataAccessObjectTest.java
+++ b/src/test/java/data_access/MovieDBDataAccessObjectTest.java
@@ -28,7 +28,7 @@ public class MovieDBDataAccessObjectTest {
 
     @Test
     public void testHasRating() {
-        assertEquals(8.2, movieDetails.getDouble("rating"), 0.0);
+        assertEquals(8.2, movieDetails.getDouble("rating"), 1.0);
     }
 
     @Test


### PR DESCRIPTION
Added functionality to the TMDB DAO for the "generate recommendation" use case.

Includes four methods in the DAO, only one of which is public and calls on the other three to construct a JSONObject containing the relevant details for a single movie.
- getCompleteMovieData (public)
- getMovieID
- getMovieDetails
- getMovieCast

Rather than manipulating entities from the Java Collections Framework, the getCompleteMovieData method returns a JSONObject with nested JSONArrays. The rationale for this decision was motivated by our plan to (potentially) store this data in the Grade API database, which also takes in JSONObjects.

Accompanying the DAO is a DataAccessException class, intended to signify failed attempts to retrieve info from the TMDB api, as well as a simple test for the getCompleteMovieData method to ensure it contains all relevant information in the specified format. 