### PR TITLE
Please read: API key update, and update tmdb data access objects to return entities instead of JSON data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 target/*
-src/main/resources/apikey
-src/main/resources/TMDB_apikey
 src/main/resources/apikeys.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/*
 src/main/resources/apikey
 src/main/resources/TMDB_apikey
+src/main/resources/apikeys.yaml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ CSC207 Fall 2024, Group # 74.
  
 A mixed-media tool for finding, rating, and saving different pieces of media.
 
+### Configuration
+Navigate to `src/main/resources/input_apikeys.yaml`, input the respective API keys, then rename the file as `apikeys.yaml`.
+
 ### Group Members + GitHub Usernames
 - Sophie Miki Erenberg ([sophie-erenberg](https://github.com/sophie-erenberg/))
 - Simon Bocoun ([sbocoun](https://github.com/sbocoun))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ CSC207 Fall 2024, Group # 74.
 A mixed-media tool for finding, rating, and saving different pieces of media.
 
 ### Configuration
-Navigate to `src/main/resources/input_apikeys.yaml`, input the respective API keys, then rename the file as `apikeys.yaml`.
+Navigate to `src/main/resources/input_apikeys.yaml`, make a copy of the file as `apikeys.yaml`, 
+then input the respective API keys.
 
 ### Group Members + GitHub Usernames
 - Sophie Miki Erenberg ([sophie-erenberg](https://github.com/sophie-erenberg/))

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
             <artifactId>json</artifactId>
             <version>20240303</version>
         </dependency>
-
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
@@ -26,6 +25,11 @@
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.3</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -64,6 +64,7 @@ public class AppBuilder {
     private final ViewManagerModel userViewManagerModel = new ViewManagerModel();
     private final ViewManagerModel mediaViewManagerModel = new ViewManagerModel();
     private final ViewManagerModel searchViewManagerModel = new ViewManagerModel();
+    // observers that listen for when the view should change
     private final ViewManager userViewManager = new ViewManager(userPanel, cardLayout, userViewManagerModel);
     private final ViewManager mediaViewManager = new ViewManager(mediaPanel, cardLayout, mediaViewManagerModel);
     private final ViewManager searchViewManager = new ViewManager(searchPanel, cardLayout, searchViewManagerModel);

--- a/src/main/java/app/Configurator.java
+++ b/src/main/java/app/Configurator.java
@@ -1,0 +1,32 @@
+package app;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Loads the relevant api keys from file.
+ */
+public class Configurator {
+    private final String tasteDiveApiKey;
+    private final String tmdbApiKey;
+
+    public Configurator() {
+        final LoaderOptions options = new LoaderOptions();
+        final Yaml yaml = new Yaml(options);
+        final InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("apikeys.yaml");
+        final Map<String, String> apikeys = yaml.loadAs(inputStream, Map.class);
+        this.tasteDiveApiKey = apikeys.get("tastedive");
+        this.tmdbApiKey = apikeys.get("tmdb");
+    }
+
+    public String getTasteDiveApiKey() {
+        return tasteDiveApiKey;
+    }
+
+    public String getTmdbApiKey() {
+        return tmdbApiKey;
+    }
+}

--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -3,7 +3,6 @@ package app;
 import data_access.DBUserDataAccessObject;
 import data_access.TasteDiveRecommendation;
 import use_case.generate_recommendations.GenDataAccessInterface;
-import use_case.note.NoteDataAccessInterface;
 
 /**
  * An application where we can view and add to a note stored by a user.
@@ -51,9 +50,10 @@ public class Main {
      */
     public static void main(String[] args) {
 
+        final Configurator configurator = new Configurator();
         final DBUserDataAccessObject userDataAccessObject = new DBUserDataAccessObject();
         final GenDataAccessInterface genDataAccessInterface = new TasteDiveRecommendation();
-        genDataAccessInterface.loadApiKeyFromFile();
+        genDataAccessInterface.setApiKey(configurator.getTasteDiveApiKey());
 
         final AppBuilder builder = new AppBuilder();
         builder.addUserDAO(userDataAccessObject)

--- a/src/main/java/data_access/DBUserDataAccessObject.java
+++ b/src/main/java/data_access/DBUserDataAccessObject.java
@@ -47,9 +47,7 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface,
                 .url(String.format("http://vm003.teach.cs.toronto.edu:20112/user?username=%s", username))
                 .addHeader(CONTENT_TYPE_LABEL, CONTENT_TYPE_JSON)
                 .build();
-        try {
-            final Response response = client.newCall(request).execute();
-
+        try (Response response = client.newCall(request).execute()) {
             final JSONObject responseBody = new JSONObject(response.body().string());
 
             if (responseBody.getInt(STATUS_CODE_LABEL) == SUCCESS_CODE) {
@@ -94,11 +92,8 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface,
                 .url(String.format("http://vm003.teach.cs.toronto.edu:20112/checkIfUserExists?username=%s", username))
                 .addHeader(CONTENT_TYPE_LABEL, CONTENT_TYPE_JSON)
                 .build();
-        try {
-            final Response response = client.newCall(request).execute();
-
+        try (Response response = client.newCall(request).execute()) {
             final JSONObject responseBody = new JSONObject(response.body().string());
-
             return responseBody.getInt(STATUS_CODE_LABEL) == SUCCESS_CODE;
         }
         catch (IOException | JSONException ex) {
@@ -122,15 +117,10 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface,
                 .method("POST", body)
                 .addHeader(CONTENT_TYPE_LABEL, CONTENT_TYPE_JSON)
                 .build();
-        try {
-            final Response response = client.newCall(request).execute();
-
+        try (Response response = client.newCall(request).execute()) {
             final JSONObject responseBody = new JSONObject(response.body().string());
 
-            if (responseBody.getInt(STATUS_CODE_LABEL) == SUCCESS_CODE) {
-                // success!
-            }
-            else {
+            if (responseBody.getInt(STATUS_CODE_LABEL) != SUCCESS_CODE) {
                 throw new RuntimeException(responseBody.getString(MESSAGE));
             }
         }
@@ -155,9 +145,7 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface,
                 .method("PUT", body)
                 .addHeader(CONTENT_TYPE_LABEL, CONTENT_TYPE_JSON)
                 .build();
-        try {
-            final Response response = client.newCall(request).execute();
-
+        try (Response response = client.newCall(request).execute()) {
             final JSONObject responseBody = new JSONObject(response.body().string());
 
             if (responseBody.getInt(STATUS_CODE_LABEL) == SUCCESS_CODE) {
@@ -197,9 +185,7 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface,
                 .method("PUT", body)
                 .addHeader(CONTENT_TYPE_LABEL, CONTENT_TYPE_JSON)
                 .build();
-        try {
-            final Response response = client.newCall(request).execute();
-
+        try (Response response = client.newCall(request).execute()) {
             final JSONObject responseBody = new JSONObject(response.body().string());
 
             if (responseBody.getInt(STATUS_CODE_LABEL) == SUCCESS_CODE) {
@@ -226,20 +212,17 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface,
                 .url(String.format("http://vm003.teach.cs.toronto.edu:20112/user?username=%s", username))
                 .addHeader(CONTENT_TYPE_LABEL, CONTENT_TYPE_JSON)
                 .build();
-        try {
-            final Response response = client.newCall(request).execute();
-
+        try (Response response = client.newCall(request).execute()) {
             final JSONObject responseBody = new JSONObject(response.body().string());
 
             if (responseBody.getInt(STATUS_CODE_LABEL) == SUCCESS_CODE) {
                 final JSONObject userJSONObject = responseBody.getJSONObject("user");
                 final JSONObject data = userJSONObject.getJSONObject(INFO);
-                if (!data.has(NOTE)) {
-                    return "";
+                String result = "";
+                if (data.has(NOTE)) {
+                    result = data.getString(NOTE);
                 }
-                else {
-                    return data.getString(NOTE);
-                }
+                return result;
             }
             else {
                 throw new DataAccessException(responseBody.getString(MESSAGE));

--- a/src/main/java/data_access/MovieDBDataAccessObject.java
+++ b/src/main/java/data_access/MovieDBDataAccessObject.java
@@ -87,9 +87,7 @@ public class MovieDBDataAccessObject implements MovieDBDataAccessInterface {
                 .get()
                 .build();
 
-        try {
-            final Response response = client.newCall(request).execute();
-
+        try (Response response = client.newCall(request).execute()) {
             final JSONObject responseBody = new JSONObject(response.body().string());
 
             if (response.isSuccessful()) {
@@ -123,9 +121,7 @@ public class MovieDBDataAccessObject implements MovieDBDataAccessInterface {
                 .addHeader(AUTHORIZATION, BEARER + apiKey)
                 .build();
 
-        try {
-            final Response response = client.newCall(request).execute();
-
+        try (Response response = client.newCall(request).execute()) {
             final JSONObject responseBody = new JSONObject(response.body().string());
 
             if (response.isSuccessful()) {
@@ -158,9 +154,7 @@ public class MovieDBDataAccessObject implements MovieDBDataAccessInterface {
                 .addHeader(AUTHORIZATION, BEARER + apiKey)
                 .build();
 
-        try {
-            final Response response = client.newCall(request).execute();
-
+        try (Response response = client.newCall(request).execute()) {
             final JSONObject responseBody = new JSONObject(response.body().string());
 
             if (response.isSuccessful()) {

--- a/src/main/java/data_access/MovieDBDataAccessObject.java
+++ b/src/main/java/data_access/MovieDBDataAccessObject.java
@@ -1,9 +1,6 @@
 package data_access;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -167,16 +164,11 @@ public class MovieDBDataAccessObject implements MovieDBDataAccessInterface {
     }
 
     /**
-     * Load the api key from the resources/apikey.
-     * @throws RuntimeException if there's an error reading the apikey file.
+     * Load the api key to be used for api calls.
+     *
+     * @param apikey the TMDB API key to be used
      */
-    public void loadApiKeyFromFile() {
-        try {
-            this.apiKey = Files.readString(Paths.get(getClass().getClassLoader()
-                    .getResource("TMDB_apikey").toURI()));
-        }
-        catch (IOException | URISyntaxException ex) {
-            throw new RuntimeException(ex);
-        }
+    public void setApiKey(String apikey) {
+        this.apiKey = apikey;
     }
 }

--- a/src/main/java/data_access/MovieDBDataAccessObject.java
+++ b/src/main/java/data_access/MovieDBDataAccessObject.java
@@ -1,11 +1,15 @@
 package data_access;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import entity.Movie;
+import entity.Rating;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -32,15 +36,38 @@ public class MovieDBDataAccessObject implements MovieDBDataAccessInterface {
 
     /**
      * Get the complete details of a movie from the TMDB.
+     *
      * @param movieName The name of the movie to be looked up.
      * @return a JSONObject containing the movie genres, cast, runtime, rating, and description.
      * @throws MovieDBDataAccessException if the TMDB API is unsuccessfully called.
      */
-    public JSONObject getCompleteMovieData(String movieName) throws MovieDBDataAccessException {
+    public Movie getMovie(String movieName) throws MovieDBDataAccessException {
         final int movieID = getMovieID(movieName);
         final JSONObject completeMovieData = getMovieDetails(movieID);
-        completeMovieData.put("cast", getMovieCast(movieID));
-        return completeMovieData;
+        final double ratingNormalized = completeMovieData.getDouble("vote_average") * 10;
+
+        final String name = completeMovieData.getString("title");
+        final List<String> genres = getGenres(completeMovieData);
+        final Rating rating = new Rating((int) ratingNormalized);
+        final String description = completeMovieData.getString("overview");
+        final List<String> castMembers = getMovieCast(movieID);
+        final int minuteRunTime = completeMovieData.getInt(RUNTIME);
+        return new Movie(name, genres, rating, description, castMembers, minuteRunTime);
+    }
+
+    /**
+     * Get the genres of a movie in the given JSON data.
+     * @param movieData JSON information from which to retrieve the genres
+     * @return list of genres
+     * @throws JSONException if the JSON information doesn't contain the correct information/format
+     */
+    private List<String> getGenres(JSONObject movieData) throws JSONException {
+        final List<String> result = new ArrayList<>();
+        final JSONArray genres = movieData.getJSONArray(GENRES);
+        for (int i = 0; i < genres.length(); i++) {
+            result.add(genres.getJSONObject(i).getString("name"));
+        }
+        return result;
     }
 
     /**
@@ -102,17 +129,7 @@ public class MovieDBDataAccessObject implements MovieDBDataAccessInterface {
             final JSONObject responseBody = new JSONObject(response.body().string());
 
             if (response.isSuccessful()) {
-                final JSONObject criticalMovieDetails = new JSONObject();
-                final JSONArray genres = responseBody.getJSONArray(GENRES);
-                final JSONArray parsedGenres = new JSONArray();
-                for (int i = 0; i < genres.length(); i++) {
-                    parsedGenres.put(genres.getJSONObject(i).getString("name"));
-                }
-                criticalMovieDetails.put(GENRES, parsedGenres);
-                criticalMovieDetails.put("rating", responseBody.getDouble("vote_average"));
-                criticalMovieDetails.put("description", responseBody.getString("overview"));
-                criticalMovieDetails.put(RUNTIME, responseBody.getInt(RUNTIME));
-                return criticalMovieDetails;
+                return responseBody;
             }
             else {
                 throw new MovieDBDataAccessException(responseBody.getString(MESSAGE));
@@ -130,7 +147,7 @@ public class MovieDBDataAccessObject implements MovieDBDataAccessInterface {
      * @throws MovieDBDataAccessException if the TMDB API is unsuccessfully called.
      * @throws RuntimeException if there's an error formatting the JSON output.
      */
-    private JSONArray getMovieCast(int movieID) throws MovieDBDataAccessException {
+    private List<String> getMovieCast(int movieID) throws MovieDBDataAccessException {
 
         final OkHttpClient client = new OkHttpClient();
 
@@ -148,9 +165,11 @@ public class MovieDBDataAccessObject implements MovieDBDataAccessInterface {
 
             if (response.isSuccessful()) {
                 final JSONArray cast = responseBody.getJSONArray("cast");
-                final JSONArray parsedCast = new JSONArray();
-                for (int i = 0; i < CAST_LIMIT; i++) {
-                    parsedCast.put(cast.getJSONObject(i).getString("name"));
+                final List<String> parsedCast = new ArrayList<>();
+                for (int i = 0; i < cast.length() && parsedCast.size() < CAST_LIMIT; i++) {
+                    if (cast.getJSONObject(i).getString("known_for_department").equals("Acting")) {
+                        parsedCast.add(cast.getJSONObject(i).getString("name"));
+                    }
                 }
                 return parsedCast;
             }

--- a/src/main/java/data_access/TasteDiveRecommendation.java
+++ b/src/main/java/data_access/TasteDiveRecommendation.java
@@ -1,9 +1,6 @@
 package data_access;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.json.JSONArray;
@@ -95,16 +92,4 @@ public class TasteDiveRecommendation implements GenDataAccessInterface {
         this.apiKey = apiKey;
     }
 
-    /**
-     * Load the api key from the resources/apikey.
-     * @throws RuntimeException if there's an error reading the apikey file.
-     */
-    public void loadApiKeyFromFile() {
-        try {
-            this.apiKey = Files.readString(Paths.get(getClass().getClassLoader().getResource("apikey").toURI()));
-        }
-        catch (IOException | URISyntaxException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
 }

--- a/src/main/java/use_case/generate_recommendations/GenDataAccessInterface.java
+++ b/src/main/java/use_case/generate_recommendations/GenDataAccessInterface.java
@@ -29,9 +29,4 @@ public interface GenDataAccessInterface {
      * @param apiKey the api key
      */
     void setApiKey(String apiKey);
-
-    /**
-     * Load the api key from resources/apikey.
-     */
-    void loadApiKeyFromFile();
 }

--- a/src/main/java/use_case/generate_recommendations/MovieDBDataAccessInterface.java
+++ b/src/main/java/use_case/generate_recommendations/MovieDBDataAccessInterface.java
@@ -1,8 +1,7 @@
 package use_case.generate_recommendations;
 
-import org.json.JSONObject;
-
 import data_access.MovieDBDataAccessException;
+import entity.Movie;
 
 /**
  * Interface for the TMDB. Includes methods for setting the API key and getting movie information.
@@ -10,12 +9,13 @@ import data_access.MovieDBDataAccessException;
 public interface MovieDBDataAccessInterface {
 
     /**
-     * Get the complete details of a movie from the TMDB.
+     * Get a Movie entity, containing the complete details of a movie from TMDB.
+     *
      * @param movieName The name of the movie to be looked up.
      * @return a JSONObject containing the movie genres, cast, runtime, rating, and description.
      * @throws MovieDBDataAccessException if the TMDB API is unsuccessfully called.
      */
-    JSONObject getCompleteMovieData(String movieName) throws MovieDBDataAccessException;
+    Movie getMovie(String movieName) throws MovieDBDataAccessException;
 
     /**
      * Sets the TMDB API key apikey.

--- a/src/main/java/use_case/generate_recommendations/MovieDBDataAccessInterface.java
+++ b/src/main/java/use_case/generate_recommendations/MovieDBDataAccessInterface.java
@@ -18,8 +18,10 @@ public interface MovieDBDataAccessInterface {
     JSONObject getCompleteMovieData(String movieName) throws MovieDBDataAccessException;
 
     /**
-     * Loads the TMDB API key from the TMDB_apikey file in resources.
+     * Sets the TMDB API key apikey.
+     *
+     * @param apikey the TMDB API key used for api calls
      */
-    void loadApiKeyFromFile();
+    void setApiKey(String apikey);
 
 }

--- a/src/main/resources/input_apikeys.yaml
+++ b/src/main/resources/input_apikeys.yaml
@@ -1,0 +1,3 @@
+# input api keys here, then rename the file to apikeys.yaml
+tastedive:
+tmdb:

--- a/src/test/java/data_access/MovieDBDataAccessObjectTest.java
+++ b/src/test/java/data_access/MovieDBDataAccessObjectTest.java
@@ -1,8 +1,10 @@
 package data_access;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import app.Configurator;
-import org.json.JSONArray;
-import org.json.JSONObject;
+import entity.Movie;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import use_case.generate_recommendations.MovieDBDataAccessInterface;
@@ -11,7 +13,7 @@ import static org.junit.Assert.*;
 
 public class MovieDBDataAccessObjectTest {
 
-    private static JSONObject movieDetails;
+    private static Movie movieDetails;
     public static final String MOVIE_NAME = "The Matrix";
 
     @BeforeClass
@@ -20,36 +22,36 @@ public class MovieDBDataAccessObjectTest {
         Configurator configurator = new Configurator();
         api.setApiKey(configurator.getTmdbApiKey());
         // Filename should be TMDB_apikey
-        movieDetails = api.getCompleteMovieData(MOVIE_NAME);
+        movieDetails = api.getMovie(MOVIE_NAME);
     }
 
     @Test
     public void testHasRuntime() {
-        assertEquals(136, movieDetails.getInt("runtime"));
+        assertEquals(136, movieDetails.getMinuteRuntime());
     }
 
     @Test
     public void testHasRating() {
-        assertEquals(8.2, movieDetails.getDouble("rating"), 1.0);
+        assertEquals(82, movieDetails.getExternalRating().getScore());
     }
 
     @Test
     public void testHasDescription() {
         assertEquals("Set in the 22nd century, The Matrix tells " +
                 "the story of a computer hacker who joins a group of underground insurgents fighting the vast and " +
-                "powerful computers who now rule the earth.", movieDetails.getString("description"));
+                "powerful computers who now rule the earth.", movieDetails.getDescription());
     }
 
     @Test
     public void testHasCast() {
-            JSONArray cast = new JSONArray(new String[] {"Keanu Reeves","Laurence Fishburne","Carrie-Anne Moss",
-                    "Hugo Weaving", "Gloria Foster"});
-            assertTrue(cast.similar(movieDetails.getJSONArray("cast")));
+        List<String> cast = new ArrayList<>(List.of(new String[]{"Keanu Reeves", "Laurence Fishburne",
+                "Carrie-Anne Moss", "Hugo Weaving", "Gloria Foster"}));
+        assertEquals(cast, movieDetails.getCastMembers());
         }
 
     @Test
     public void testHasGenres() {
-        JSONArray genres = new JSONArray(new String[] {"Action", "Science Fiction"});
-        assertTrue(genres.similar(movieDetails.getJSONArray("genres")));
+        List<String> genres = new ArrayList<>(List.of(new String[]{"Action", "Science Fiction"}));
+        assertEquals(genres, movieDetails.getGenres());
     }
 }

--- a/src/test/java/data_access/MovieDBDataAccessObjectTest.java
+++ b/src/test/java/data_access/MovieDBDataAccessObjectTest.java
@@ -1,5 +1,6 @@
 package data_access;
 
+import app.Configurator;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
@@ -16,7 +17,8 @@ public class MovieDBDataAccessObjectTest {
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         MovieDBDataAccessInterface api = new MovieDBDataAccessObject();
-        api.loadApiKeyFromFile();
+        Configurator configurator = new Configurator();
+        api.setApiKey(configurator.getTmdbApiKey());
         // Filename should be TMDB_apikey
         movieDetails = api.getCompleteMovieData(MOVIE_NAME);
     }

--- a/src/test/java/data_access/TasteDiveApiAccessObjectTest.java
+++ b/src/test/java/data_access/TasteDiveApiAccessObjectTest.java
@@ -1,5 +1,6 @@
 package data_access;
 
+import app.Configurator;
 import org.junit.Test;
 import use_case.note.DataAccessException;
 import use_case.generate_recommendations.GenDataAccessInterface;
@@ -13,8 +14,9 @@ public class TasteDiveApiAccessObjectTest {
 
     @Test
     public void testApi() {
+        Configurator configurator = new Configurator();
         GenDataAccessInterface api = new TasteDiveRecommendation();
-        api.loadApiKeyFromFile();
+        api.setApiKey(configurator.getTasteDiveApiKey());
         List<String> base = new ArrayList<>();
         base.add("Alien Romulus");
         base.add("late night with the devil");


### PR DESCRIPTION
# Important:
I made a few changes to how API keys are loaded. So instead of loading the keys from two separate files (`apikey` and `TMDB_apikey`) under `src/main/resources`, it'll be a single file `apikeys.yaml` under the same directory.
I provided a default file `input_apikeys.yaml`, so the only change you need to do is 
1. make a copy of `input_apikeys.yaml` as `apikeys.yaml`, and
2. put in the corresponding keys in the corresponding fields in the file
3. delete the old `apikey` and `TMDB_apikey` files in the resources directory

### The other change in this pull request:
`MovieDBDataAccessObject` and the related interface `MovieDBDataAccessInterface` are updated to return a Movie entity instead of just generic JSON data for interactors to use.