### PR TITLE
Implemented the classes necessary for converting our JSON User representation to User entities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
 
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -7,7 +7,7 @@ import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.WindowConstants;
 
-import data_access.DBUserDataAccessObject;
+import data_access.grade_api.DBUserDataAccessObject;
 import interface_adapter.ViewManagerModel;
 import interface_adapter.change_password.ChangePasswordController;
 import interface_adapter.change_password.ChangePasswordPresenter;
@@ -39,7 +39,6 @@ import use_case.login.LoginOutputBoundary;
 import use_case.logout.LogoutInputBoundary;
 import use_case.logout.LogoutInteractor;
 import use_case.logout.LogoutOutputBoundary;
-import use_case.note.NoteDataAccessInterface;
 import use_case.note.NoteInteractor;
 import use_case.note.NoteOutputBoundary;
 import use_case.signup.SignupInputBoundary;

--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -1,9 +1,8 @@
 package app;
 
-import data_access.DBUserDataAccessObject;
 import data_access.TasteDiveRecommendation;
+import data_access.grade_api.DBUserDataAccessObject;
 import use_case.generate_recommendations.GenDataAccessInterface;
-import use_case.note.NoteDataAccessInterface;
 
 /**
  * An application where we can view and add to a note stored by a user.

--- a/src/main/java/data_access/grade_api/DBUserDataAccessObject.java
+++ b/src/main/java/data_access/grade_api/DBUserDataAccessObject.java
@@ -1,4 +1,4 @@
-package data_access;
+package data_access.grade_api;
 
 import java.io.IOException;
 
@@ -54,18 +54,8 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface,
 
             if (responseBody.getInt(STATUS_CODE_LABEL) == SUCCESS_CODE) {
                 final JSONObject userJSONObject = responseBody.getJSONObject("user");
-                final String name = userJSONObject.getString(USERNAME);
-                final String password = userJSONObject.getString(PASSWORD);
-                final JSONObject data = userJSONObject.getJSONObject(INFO);
-                final String notes;
-                if (!data.has(NOTE)) {
-                    notes = "";
-                }
-                else {
-                    notes = data.getString(NOTE);
-                }
-
-                return new User(name, password, notes);
+                final UserBuilder userBuilder = new UserBuilder();
+                return userBuilder.createUser(userJSONObject);
             }
             else {
                 throw new RuntimeException(responseBody.getString(MESSAGE));
@@ -249,5 +239,4 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface,
             throw new RuntimeException(ex);
         }
     }
-
 }

--- a/src/main/java/data_access/grade_api/MediaCollectionBuilder.java
+++ b/src/main/java/data_access/grade_api/MediaCollectionBuilder.java
@@ -1,0 +1,38 @@
+package data_access.grade_api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONObject;
+
+import entity.MediaCollection;
+
+/**
+ * A builder for creating MediaCollection objects from JSON data.
+ * @param <T> the type of media being created
+ */
+public class MediaCollectionBuilder<T> {
+
+    private final Class<T> type;
+
+    public MediaCollectionBuilder(Class<T> type) {
+        this.type = type;
+    }
+
+    /**
+     * Creates a MediaCollection object from JSON data.
+     * @param collection the JSON data to create the MediaCollection object from
+     * @return the MediaCollection object created from the JSON data
+     */
+    public MediaCollection<T> createCollection(JSONObject collection) {
+        final String collectionName = collection.getString("name");
+        final String collectionType = collection.getString("collectionType");
+        final List<T> mediaList = new ArrayList<>();
+        for (int i = 0; i < collection.getJSONArray("media").length(); i++) {
+            final JSONObject media = collection.getJSONArray("media").getJSONObject(i);
+            final MediaFactory<T> mediaFactory = new MediaFactory<>(type);
+            mediaList.add(mediaFactory.createMedia(media));
+        }
+        return new MediaCollection<>(collectionName, collectionType, type, mediaList);
+    }
+}

--- a/src/main/java/data_access/grade_api/MediaFactory.java
+++ b/src/main/java/data_access/grade_api/MediaFactory.java
@@ -1,0 +1,69 @@
+package data_access.grade_api;
+
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import entity.Movie;
+import entity.Rating;
+
+/**
+ * A factory for creating media collections.
+ * @param <T> the type of media being created
+ */
+public final class MediaFactory<T> {
+
+    private final Class<T> type;
+
+    public MediaFactory(Class<T> type) {
+        this.type = type;
+    }
+
+    /**
+     * Creates a MediaCollection object from JSON data.
+     * @param media the JSON data to create the Media object from
+     * @return the MediaCollection object created from the JSON data
+     */
+    public T createMedia(JSONObject media) {
+        return switch (type.getName()) {
+            case "entity.Movie" -> movieConstructor(media);
+            case "entity.TVShow" -> tvShowConstructor(media);
+            case "entity.Music" -> musicConstructor(media);
+            default -> null;
+        };
+    }
+
+    private T musicConstructor(JSONObject media) {
+        return null;
+    }
+
+    private T tvShowConstructor(JSONObject media) {
+        return null;
+    }
+
+    private T movieConstructor(JSONObject media) {
+        final JSONArray genresJSON = media.getJSONArray("genres");
+        final List<String> genres = new java.util.ArrayList<>();
+        for (int i = 0; i < genresJSON.length(); i++) {
+            genres.add(genresJSON.getString(i));
+        }
+        final JSONArray actorsJSON = media.getJSONArray("cast");
+        final List<String> actors = new java.util.ArrayList<>();
+        for (int i = 0; i < actorsJSON.length(); i++) {
+            actors.add(actorsJSON.getString(i));
+        }
+        final Movie result = new Movie(media.getString("name"),
+                genres,
+                new Rating(media.getInt("rating")),
+                media.getString("description"),
+                actors,
+                media.getInt("runtime"));
+        if (type.isInstance(result)) {
+            return type.cast(result);
+        }
+        else {
+            throw new IllegalArgumentException("Invalid media type");
+        }
+    }
+}

--- a/src/main/java/data_access/grade_api/UserBuilder.java
+++ b/src/main/java/data_access/grade_api/UserBuilder.java
@@ -1,0 +1,55 @@
+package data_access.grade_api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import entity.AbstractMedia;
+import entity.MediaCollection;
+import entity.Movie;
+import entity.User;
+
+/**
+ * A builder for creating User objects from JSON data.
+ */
+public class UserBuilder {
+
+    /**
+     * Creates a User object from JSON data.
+     *
+     * @param data the JSON data to create the User object from
+     * @return the User object created from the JSON data
+     * @throws UnsupportedOperationException if the media type is not supported
+     */
+    public User createUser(JSONObject data) throws UnsupportedOperationException {
+        final User user = new User(data.getString("username"), data.getString("password"));
+        final List<MediaCollection<? extends AbstractMedia>> mediaCollections = new ArrayList<>();
+        final JSONArray collections;
+        if (data.get("info") instanceof JSONObject) {
+            user.setMediaCollections(mediaCollections);
+            return user;
+        }
+        else {
+            collections = (JSONArray) data.get("info");
+        }
+        for (int i = 0; i < collections.length(); i++) {
+            final JSONObject collectionJSON = collections.getJSONObject(i);
+            switch (collectionJSON.getString("mediaType")) {
+                case "entity.Movie" -> {
+                    final MediaCollectionBuilder<Movie> movieBuilder = new MediaCollectionBuilder<>(Movie.class);
+                    mediaCollections.add(movieBuilder.createCollection(collectionJSON));
+                }
+                case "entity.TV_Show" -> {
+                    throw new UnsupportedOperationException("TV shows are not supported yet.");
+                }
+                default -> {
+                    throw new UnsupportedOperationException("Unsupported entity type.");
+                }
+            }
+        }
+        user.setMediaCollections(mediaCollections);
+        return user;
+    }
+}

--- a/src/main/java/entity/MediaCollection.java
+++ b/src/main/java/entity/MediaCollection.java
@@ -4,23 +4,26 @@ import java.util.List;
 
 /**
  * The representation of a list of media.
- *
- * @param <T> the type of media stored in the collection.
+ * @param <T> the type of media stored in the collection
  */
 public class MediaCollection<T> {
     private String name;
     private final String collectionType;
+    private final Class<T> mediaType;
     private final List<T> mediaList;
 
     /**
      * Constructs a list of Media.
      * @param name the name of the list, provided by the user
      * @param collectionType the watch status type of the collection
+     *                 (e.g. "watched", "to watch", "watching")
+     * @param mediaType the type of media stored in the collection
      * @param mediaList the list of media contained in the collection
      */
-    MediaCollection(String name, String collectionType, List<T> mediaList) {
+    public MediaCollection(String name, String collectionType, Class<T> mediaType, List<T> mediaList) {
         this.name = name;
         this.collectionType = collectionType;
+        this.mediaType = mediaType;
         this.mediaList = mediaList;
     }
 
@@ -42,5 +45,29 @@ public class MediaCollection<T> {
      */
     public List<T> getMediaList() {
         return mediaList;
+    }
+
+    /**
+     * Add a piece of media to the collection.
+     * @param media the media to add
+     */
+    public void addMedia(T media) {
+        mediaList.add(media);
+    }
+
+    /**
+     * Remove a piece of media from the collection.
+     * @param media the media to remove
+     */
+    public void removeMedia(T media) {
+        mediaList.remove(media);
+    }
+
+    /**
+     * Return the type of media stored in the collection.
+     * @return the type of media stored in the collection
+     */
+    public Class<T> getMediaType() {
+        return mediaType;
     }
 }

--- a/src/main/java/entity/User.java
+++ b/src/main/java/entity/User.java
@@ -1,5 +1,6 @@
 package entity;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -9,7 +10,7 @@ public class User {
 
     private String name;
     private String password;
-    private List<MediaCollection<AbstractMedia>> mediaCollections;
+    private List<MediaCollection<? extends AbstractMedia>> mediaCollections;
     // This is temporary before the JSON to entity parser is implemented
     private String notes;
 
@@ -39,12 +40,23 @@ public class User {
         this.password = password;
     }
 
-    public List<MediaCollection<AbstractMedia>> getMediaCollections() {
-        return mediaCollections;
+    public void setMediaCollections(List<MediaCollection<? extends AbstractMedia>> mediaCollections) {
+        this.mediaCollections = mediaCollections;
     }
 
-    public void setMediaCollections(List<MediaCollection<AbstractMedia>> mediaCollections) {
-        this.mediaCollections = mediaCollections;
+    /**
+     * Return a (mutable) list of media collections.
+     * @return a list of media collections
+     */
+    @SuppressWarnings("unchecked")
+    public List<MediaCollection<Movie>> getMediaCollectionsMovies() {
+        final List<MediaCollection<Movie>> movieCollections = new ArrayList<>();
+        for (MediaCollection<? extends AbstractMedia> mediaCollection : mediaCollections) {
+            if (mediaCollection.getMediaType() == Movie.class) {
+                movieCollections.add((MediaCollection<Movie>) mediaCollection);
+            }
+        }
+        return movieCollections;
     }
 
     public String getNotes() {


### PR DESCRIPTION
I made the decision to instantiate MediaCollections to the individual subclasses of AbstractMedia rather than AbstractMedia itself. To make the retrieval process easier, I added an instance variable to the MediaCollection entity containing the Class type of the media stored in the Collection. Currently:
- The Grade API DAO instantiates and calls an instance of the UserBuilder class.
- The UserBuilder class utilizes a switch statement to determine (for each stored collection) what type of media to populate it with.
- The MediaCollectionBuilder is responsible for creating each stored collection, and calls on the MediaFactory class to create each piece of media.
- The MediaFactory class contains another switch statement that determines what entity to instantiate the media JSON data to.

Consequences of this decision:
- The type of Media in the MediaCollection of each user is dynamic. That means simply returning the list of MediaCollections wouldn't give any guarantee about the type of Media stored in each collection, which isn't allowed. Thus, each MediaType will necessitate its own return method in the user class (e.g. User.getMediaCollectionsMovies).
- To support class tokens, the compiler needs to be version 16 or above.