### PR TITLE
4-filtering-a-list-by-criteria

### DIFF
--- a/src/main/java/interface_adapter/filter_list/FilterState.java
+++ b/src/main/java/interface_adapter/filter_list/FilterState.java
@@ -5,15 +5,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
-
 /**
  * The ViewModel for the FilterView.
  */
 public class FilterState {
 
     private final Map<String, String> filterCriteria = new HashMap<>();
-    private List<String> filteredMediaNames = new ArrayList<>();
+    private final List<String> filteredMediaNames = new ArrayList<>();
     private String errorMessage = "";
 
     /**
@@ -42,7 +40,6 @@ public class FilterState {
      * displayed.
      * @return The list of media names.
      */
-    @Nullable
     public List<String> getFilteredMediaNames() {
         return filteredMediaNames;
     }
@@ -50,16 +47,11 @@ public class FilterState {
     /**
      * Sets the list of media names meant to be passed to the list panel and
      * displayed.
-     * @param filteredMediaNames The list of media names, can be null to
-     *                           signify no media should be filtered.
+     * @param filteredMediaNames The list of media names to display.
      */
     public void setFilteredMediaNames(List<String> filteredMediaNames) {
-        if (filteredMediaNames != null) {
-            this.filteredMediaNames = new ArrayList<>(filteredMediaNames);
-        }
-        else {
-            this.filteredMediaNames = null;
-        }
+        this.filteredMediaNames.clear();
+        this.filteredMediaNames.addAll(filteredMediaNames);
     }
 
     /**

--- a/src/main/java/use_case/filter_list/FilterDataAccessInterface.java
+++ b/src/main/java/use_case/filter_list/FilterDataAccessInterface.java
@@ -18,4 +18,10 @@ public interface FilterDataAccessInterface {
      * @return the named collection of media
      */
     <T extends AbstractMedia> MediaCollection<T> getNamedCollection(String collectionName, String mediaType);
+
+    /**
+     * Retrieve the current username.
+     * @return the current username
+     */
+    String getCurrentUsername();
 }

--- a/src/main/java/use_case/filter_list/FilterInteractor.java
+++ b/src/main/java/use_case/filter_list/FilterInteractor.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import data_access.grade_api.UserRepository;
 import entity.AbstractMedia;
 import entity.MediaCollection;
 import use_case.filter_list.filter_strategies.FilterStrategy;
@@ -17,11 +16,11 @@ import use_case.filter_list.filter_strategies.TelevisionFilterStrategy;
  */
 public class FilterInteractor implements FilterInputBoundary {
 
-    private final UserRepository userDAO;
+    private final FilterDataAccessInterface userDAO;
     private final FilterListOutputBoundary filterPresenter;
     private final Map<String, FilterStrategy> strategies = new HashMap<>();
 
-    public FilterInteractor(FilterListOutputBoundary filterPresenter, UserRepository userDataAccessObject) {
+    public FilterInteractor(FilterListOutputBoundary filterPresenter, FilterDataAccessInterface userDataAccessObject) {
         this.filterPresenter = filterPresenter;
         this.userDAO = userDataAccessObject;
         strategies.put("entity.Movie", new MovieFilterStrategy());

--- a/src/main/java/use_case/filter_list/filter_strategies/FormattingHelpers.java
+++ b/src/main/java/use_case/filter_list/filter_strategies/FormattingHelpers.java
@@ -11,28 +11,28 @@ import java.util.Set;
 public class FormattingHelpers {
 
     /**
-     * Converts a list of strings to lowercase.
+     * Converts the contents of a list of strings to lowercase.
      *
      * @param list The list to convert.
      * @return The list with all strings converted to lowercase.
      */
-    List<String> toLowercase(List<String> list) {
+    List<String> listToLowercase(List<String> list) {
         return list.stream().map(String::toLowerCase).toList();
     }
 
     /**
-     * Splits the description into a set of lowercase words.
+     * Splits the input string into a set of lowercase words.
      *
-     * @param description The description to split.
+     * @param input The description to split.
      * @return The keywords.
      */
-    Set<String> splitDescription(String description) {
-        final List<String> keywordArray = Arrays.stream(description
+    Set<String> splitString(String input) {
+        final List<String> result = Arrays.stream(input
                         .replaceAll("\\p{Punct}", "")
                         .toLowerCase()
                         .split("\\s+"))
                 .toList();
-        return new HashSet<>(keywordArray);
+        return new HashSet<>(result);
     }
 
     /**

--- a/src/main/java/use_case/filter_list/filter_strategies/FormattingHelpers.java
+++ b/src/main/java/use_case/filter_list/filter_strategies/FormattingHelpers.java
@@ -42,6 +42,6 @@ public class FormattingHelpers {
      * @return whether the set is not empty.
      */
     boolean notEmpty(Set<String> set) {
-        return !set.isEmpty() && (set.size() != 1 || !set.contains(""));
+        return !set.isEmpty() && !set.contains("");
     }
 }

--- a/src/main/java/use_case/filter_list/filter_strategies/FormattingHelpers.java
+++ b/src/main/java/use_case/filter_list/filter_strategies/FormattingHelpers.java
@@ -36,12 +36,12 @@ public class FormattingHelpers {
     }
 
     /**
-     * Checks if a set is not empty, empty string excluded.
+     * Checks if a set is not empty by checking if it contains an empty string.
      *
      * @param set The set of strings to check
      * @return whether the set is not empty.
      */
     boolean notEmpty(Set<String> set) {
-        return !set.isEmpty() && !set.contains("");
+        return !set.contains("");
     }
 }

--- a/src/main/java/use_case/filter_list/filter_strategies/MovieFilterStrategy.java
+++ b/src/main/java/use_case/filter_list/filter_strategies/MovieFilterStrategy.java
@@ -20,23 +20,28 @@ public class MovieFilterStrategy implements FilterStrategy {
         boolean result = true;
         final Movie movie = (Movie) media;
 
+        // Splits the description into a set of keywords.
         final Set<String> movieKeywords =
-                formattingHelper.splitDescription(movie.getDescription());
-        // Calls on notEmpty() to exclude empty strings from being considered as keywords.
+                formattingHelper.splitString(movie.getDescription());
+        // Calls on notEmpty() to exclude empty strings from being considered as keywords,
+        // then checks if the movie's keywords contain all the filter criteria keywords.
         if (formattingHelper.notEmpty(filterCriteria.get("keywords"))
                 && !movieKeywords.containsAll(filterCriteria.get("keywords"))) {
             result = false;
         }
 
         final Set<String> movieGenres = new HashSet<>(
-                formattingHelper.toLowercase(movie.getGenres()));
+                formattingHelper.listToLowercase(movie.getGenres()));
         if (formattingHelper.notEmpty(filterCriteria.get("genres"))
                 && !movieGenres.containsAll(filterCriteria.get("genres"))) {
             result = false;
         }
 
-        final Set<String> movieActors = new HashSet<>(
-                formattingHelper.toLowercase(movie.getCastMembers()));
+        final Set<String> movieActors = new HashSet<>();
+        // Splits the actors' full names into a set of keywords.
+        for (String actor : movie.getCastMembers()) {
+            movieActors.addAll(formattingHelper.splitString(actor));
+        }
         if (formattingHelper.notEmpty(filterCriteria.get("actors"))
                 && !movieActors.containsAll(filterCriteria.get("actors"))) {
             result = false;

--- a/src/main/java/use_case/filter_list/filter_strategies/TelevisionFilterStrategy.java
+++ b/src/main/java/use_case/filter_list/filter_strategies/TelevisionFilterStrategy.java
@@ -19,24 +19,28 @@ public class TelevisionFilterStrategy implements FilterStrategy {
         boolean result = true;
         final Television show = (Television) media;
 
+        // Splits the description into a set of keywords.
         final Set<String> showKeywords =
-                formattingHelper.splitDescription(show.getDescription());
-        // Calls on notEmpty() to exclude empty strings from being considered as keywords.
-        // Assumes the filter controller formats each keyword to lowercase.
+                formattingHelper.splitString(show.getDescription());
+        // Calls on notEmpty() to exclude empty strings from being considered as keywords,
+        // then checks if the movie's keywords contain all the filter criteria keywords.
         if (formattingHelper.notEmpty(filterCriteria.get("keywords"))
                 && !showKeywords.containsAll(filterCriteria.get("keywords"))) {
             result = false;
         }
 
         final Set<String> showGenres = new HashSet<>(
-                formattingHelper.toLowercase(show.getGenres()));
+                formattingHelper.listToLowercase(show.getGenres()));
         if (formattingHelper.notEmpty(filterCriteria.get("genres"))
                 && !showGenres.containsAll(filterCriteria.get("genres"))) {
             result = false;
         }
 
-        final Set<String> showActors = new HashSet<>(
-                formattingHelper.toLowercase(show.getCastMembers()));
+        final Set<String> showActors = new HashSet<>();
+        // Splits the actors' full names into a set of keywords.
+        for (String actor : show.getCastMembers()) {
+            showActors.addAll(formattingHelper.splitString(actor));
+        }
         if (formattingHelper.notEmpty(filterCriteria.get("actors"))
                 && !showActors.containsAll(filterCriteria.get("actors"))) {
             result = false;

--- a/src/main/java/view/ListView.java
+++ b/src/main/java/view/ListView.java
@@ -284,25 +284,14 @@ public class ListView extends JPanel implements ActionListener, PropertyChangeLi
     private void handleFilterViewModelChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals("filtered media")) {
             final TableRowSorter<?> sorter = (TableRowSorter<?>) mediaListTable.getRowSorter();
-            // Checks if the filter criteria is null, if so, sets the row filter to null to display all media.
-            // Otherwise, sets the row filter to only display media that matches the filter criteria.
-            // Also checks if the mediaListTable has a row sorter, if not, sets the row filter to null.
-            if (mediaListTable.getRowSorter() == null) {
-                mediaListTable.setRowSorter(new TableRowSorter<>(mediaListTable.getModel()));
-            }
-            if (filterViewModel.getState().getFilteredMediaNames() == null) {
-                sorter.setRowFilter(null);
-            }
-            else {
-                final RowFilter<TableModel, Integer> rf = new RowFilter<>() {
-                    @Override
-                    public boolean include(Entry<? extends TableModel, ? extends Integer> entry) {
-                        final String name = (String) entry.getValue(0);
-                        return filterViewModel.getState().getFilteredMediaNames().contains(name);
-                    }
-                };
-                sorter.setRowFilter(rf);
-            }
+            final RowFilter<TableModel, Integer> rf = new RowFilter<>() {
+                @Override
+                public boolean include(Entry<? extends TableModel, ? extends Integer> entry) {
+                    final String name = (String) entry.getValue(0);
+                    return filterViewModel.getState().getFilteredMediaNames().contains(name);
+                }
+            };
+            sorter.setRowFilter(rf);
         }
         else if ("error".equals(evt.getPropertyName())) {
             JOptionPane.showMessageDialog(null,

--- a/src/main/java/view/ListView.java
+++ b/src/main/java/view/ListView.java
@@ -173,11 +173,12 @@ public class ListView extends JPanel implements ActionListener, PropertyChangeLi
         clearButton.addActionListener(
                 evt -> {
                     if (evt.getSource().equals(clearButton)) {
-                        // clears the input for the currently displayed filter panel
+                        // clears the input of the currently displayed filter panel,
+                        // then executes the filter controller with the cleared filter criteria.
                         filterPanelManager.clearFilterPanel();
-                        // clears the filter criteria in the filter view model
-                        filterViewModel.getState().setFilteredMediaNames(null);
-                        filterViewModel.firePropertyChanged("filtered media");
+                        filterController.execute(filterViewModel.getState().getFilterCriteria(),
+                                listViewModel.getState().getCurrentCollectionType(),
+                                listViewModel.getState().getCurrentCollectionName());
                     }
                 }
         );
@@ -283,8 +284,12 @@ public class ListView extends JPanel implements ActionListener, PropertyChangeLi
     private void handleFilterViewModelChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals("filtered media")) {
             final TableRowSorter<?> sorter = (TableRowSorter<?>) mediaListTable.getRowSorter();
-            // Checks if the filter criteria is null, if so, sets the row filter to null to display all media
-            // Otherwise, sets the row filter to only display media that matches the filter criteria
+            // Checks if the filter criteria is null, if so, sets the row filter to null to display all media.
+            // Otherwise, sets the row filter to only display media that matches the filter criteria.
+            // Also checks if the mediaListTable has a row sorter, if not, sets the row filter to null.
+            if (mediaListTable.getRowSorter() == null) {
+                mediaListTable.setRowSorter(new TableRowSorter<>(mediaListTable.getModel()));
+            }
             if (filterViewModel.getState().getFilteredMediaNames() == null) {
                 sorter.setRowFilter(null);
             }

--- a/src/main/java/view/ListView.java
+++ b/src/main/java/view/ListView.java
@@ -173,7 +173,7 @@ public class ListView extends JPanel implements ActionListener, PropertyChangeLi
         clearButton.addActionListener(
                 evt -> {
                     if (evt.getSource().equals(clearButton)) {
-                        // clears the input of the currently displayed filter panel,
+                        // Clears the input of the currently displayed filter panel,
                         // then executes the filter controller with the cleared filter criteria.
                         filterPanelManager.clearFilterPanel();
                         filterController.execute(filterViewModel.getState().getFilterCriteria(),
@@ -283,10 +283,12 @@ public class ListView extends JPanel implements ActionListener, PropertyChangeLi
      */
     private void handleFilterViewModelChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals("filtered media")) {
+            // Updates the RowFilter to filter out anything not in the filteredMediaNames list
             final TableRowSorter<?> sorter = (TableRowSorter<?>) mediaListTable.getRowSorter();
             final RowFilter<TableModel, Integer> rf = new RowFilter<>() {
                 @Override
                 public boolean include(Entry<? extends TableModel, ? extends Integer> entry) {
+                    // Assumes the first column of the table is the name of the media
                     final String name = (String) entry.getValue(0);
                     return filterViewModel.getState().getFilteredMediaNames().contains(name);
                 }
@@ -344,6 +346,8 @@ public class ListView extends JPanel implements ActionListener, PropertyChangeLi
         else {
             SwingUtilities.invokeLater(() -> {
                 mediaListTable.setModel(newTableModel);
+                // Necessary to update the row sorter in case the number of columns has changed
+                // (e.g. when switching between different types of media collections)
                 mediaListTable.setRowSorter(new TableRowSorter<>(newTableModel));
                 newTableModel.fireTableDataChanged();
             });

--- a/src/test/java/use_case/filter/MovieStrategyTest.java
+++ b/src/test/java/use_case/filter/MovieStrategyTest.java
@@ -68,7 +68,7 @@ class MovieStrategyTest {
 
     @Test
     void testMovieFilterJustActors() {
-        testMovieStrategy(Map.of("genres", Set.of(""), "actors", Set.of("actor 1"), "keywords", Set.of("")), List.of("Test Movie"));
+        testMovieStrategy(Map.of("genres", Set.of(""), "actors", Set.of("actor", "1"), "keywords", Set.of("")), List.of("Test Movie"));
     }
 
     @Test
@@ -83,7 +83,7 @@ class MovieStrategyTest {
 
     @Test
     void testMovieFilterAll() {
-        testMovieStrategy(Map.of("genres", Set.of("action"), "actors", Set.of("actor 1"), "keywords", Set.of("description")), List.of("Test Movie"));
+        testMovieStrategy(Map.of("genres", Set.of("action"), "actors", Set.of("actor", "1"), "keywords", Set.of("description")), List.of("Test Movie"));
     }
 
     @Test

--- a/src/test/java/use_case/filter/TelevisionStrategyTest.java
+++ b/src/test/java/use_case/filter/TelevisionStrategyTest.java
@@ -67,7 +67,7 @@ class TelevisionStrategyTest {
 
    @Test
        void testTelevisionFilterJustActors() {
-        testTelevisionStrategy(Map.of("genres", Set.of(""), "actors", Set.of("actor 1"), "keywords", Set.of("")), List.of("Test Show"));
+        testTelevisionStrategy(Map.of("genres", Set.of(""), "actors", Set.of("actor", "1"), "keywords", Set.of("")), List.of("Test Show"));
     }
 
     @Test
@@ -82,7 +82,7 @@ class TelevisionStrategyTest {
 
     @Test
     void testTelevisionFilterMultipleGenres() {
-        testTelevisionStrategy(Map.of("genres", Set.of("action"), "actors", Set.of("actor 1"), "keywords", Set.of("description")), List.of("Test Show"));
+        testTelevisionStrategy(Map.of("genres", Set.of("action"), "actors", Set.of("actor", "1"), "keywords", Set.of("description")), List.of("Test Show"));
     }
 
     @Test


### PR DESCRIPTION
Reverts changes to the "clear filters" use scenario, since directly updating the filter state and passing null to the RowSorter triggered a null pointer exception if the user tried to clear filters before logging in. Calling the use case interactor may be more roundabout, but it gives robust error handling opportunities.